### PR TITLE
Removed spaces from lnhashview

### DIFF
--- a/python/exhash/__init__.py
+++ b/python/exhash/__init__.py
@@ -14,12 +14,12 @@ def lnhash(lineno:int, line:str) -> str:
 
 
 def lnhashview(text:str, start:int=None, end:int=None) -> list[str]:
-    'Return lines formatted as ``lineno|hash|  content``. Optional 1-based ``start``/``end`` filter the range; ``end`` past EOF is clamped.'
+    'Return lines formatted as ``lineno|hash|content``. Optional 1-based ``start``/``end`` filter the range; ``end`` past EOF is clamped.'
     return _lnhashview(text, start, end)
 
 
 def lnhashview_file(path:str, start:int=None, end:int=None) -> list[str]:
-    'Return lines formatted as ``lineno|hash|  content`` for file at ``path``. Optional 1-based ``start``/``end`` filter the range; ``end`` past EOF is clamped.'
+    'Return lines formatted as ``lineno|hash|content`` for file at ``path``. Optional 1-based ``start``/``end`` filter the range; ``end`` past EOF is clamped.'
     return _lnhashview(Path(path).read_text(), start, end)
 
 

--- a/src/lnhash.rs
+++ b/src/lnhash.rs
@@ -58,7 +58,7 @@ pub fn lnhashview(
         .enumerate()
         .skip(s - 1)
         .take(e - s + 1)
-        .map(|(i, l)| format!("{}  {}", format_lnhash(i + 1, l), l))
+        .map(|(i, l)| format!("{}{}", format_lnhash(i + 1, l), l))
         .collect())
 }
 

--- a/src/lnhash.rs
+++ b/src/lnhash.rs
@@ -25,7 +25,7 @@ pub fn format_lnhash(lineno: usize, line: &str) -> String {
     format!("{}|{:04x}|", lineno, line_hash_u16(line))
 }
 
-/// Format lines as `lineno|hash|  content` for a range of lines.
+/// Format lines as `lineno|hash|content` for a range of lines.
 /// `start` and `end` are 1-based inclusive. Pass `None` for defaults (1 and len).
 /// `end` past EOF is clamped to the last line.
 /// Returns an error if start is 0, end < start, or start is beyond EOF.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,13 +19,13 @@ def test_lnhashview_basic_and_range(tmp_path):
     out = runlv([str(f)])
     assert out.returncode == 0
     assert out.stdout == "".join(s + "\n" for s in (
-        f"{lnhash(1, 'alpha')}  alpha", f"{lnhash(2, 'beta')}  beta",
-        f"{lnhash(3, '')}  ", f"{lnhash(4, 'gamma')}  gamma"))
+        f"{lnhash(1, 'alpha')}alpha", f"{lnhash(2, 'beta')}beta",
+        f"{lnhash(3, '')}", f"{lnhash(4, 'gamma')}gamma"))
     out = runlv([str(f), "2", "3"])
-    assert out.stdout == f"{lnhash(2, 'beta')}  beta\n{lnhash(3, '')}  \n"
+    assert out.stdout == f"{lnhash(2, 'beta')}beta\n{lnhash(3, '')}\n"
     out = runlv([str(f), "2", "260"])
     assert out.stdout == "".join(s + "\n" for s in (
-        f"{lnhash(2, 'beta')}  beta", f"{lnhash(3, '')}  ", f"{lnhash(4, 'gamma')}  gamma"))
+        f"{lnhash(2, 'beta')}beta", f"{lnhash(3, '')}", f"{lnhash(4, 'gamma')}gamma"))
 
 def test_inplace_substitute(tmp_path):
     f = tmp_path / "f.txt"

--- a/tests/test_exhash.py
+++ b/tests/test_exhash.py
@@ -19,8 +19,8 @@ def test_lnhash_format():
 def test_lnhashview():
     lines = lnhashview("a\nb\nc")
     assert len(lines) == 3
-    assert lines[0].endswith("  a")
-    assert lines[2].endswith("  c")
+    assert lines[0].endswith("|a")
+    assert lines[2].endswith("|c")
     assert lines[0].startswith(lnhash(1, "a"))
 
 def test_lnhashview_empty(): assert lnhashview("") == []


### PR DESCRIPTION
`lnhashview` adds 2 formatting spaces between the line number & hash and the actual content. Because of that, a method defined with 0 indentation looks like this:

`lineno|hash|  def method...` (notice the 2 space between `hash|` and `def` )

This tripped GLM 5.2 following edits into thinking it was indented wth 2 / 6 spaces instead of simply 0/4. 

I just removed those spaces from the output so we get:

`lineno|hash|def method...`

There's a full notebook here reproducing the error twice, and then showing 2 good examples after the fix:

https://share.solveit.pub/d/a8ec6a713eb8202de9bb05a5ecb21b4a

**Note**

This does not happen with all edit modes:

- **`s` (substitute)**: only replaces matched text and leaves the rest of the line untouched so indentation preserved automatically.
- **`c` / `a` / `i` (change/append/insert)**: the LLM has to provide the full replacement text so if it copies it from lnhashview's `lineno|hash|  content` display, the 2-space separator gets included as real indentation and it breaks
