### PR TITLE
Publish the Rust crate through trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - id: crates-auth
+        uses: rust-lang/crates-io-auth-action@v1
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
       - uses: actions/download-artifact@v8
         with:
           path: dist


### PR DESCRIPTION
Publish tagged releases to crates.io using the official authentication action and a short-lived token. Keep the existing GitHub and PyPI publishing steps in the same release job.